### PR TITLE
feat: default to window.fetch() when run in browser env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -87,6 +93,20 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -108,6 +128,12 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "3.3.0",
@@ -199,6 +225,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -313,6 +348,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
@@ -662,6 +703,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -791,6 +838,12 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A Javascript library that wraps the imgix public API",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "test:browser": "open './test/browser/test.html'",
+    "test:all": "npm test && npm run test:browser",
+    "test:watch": "mocha --watch"
   },
   "keywords": [
     "imgix",
@@ -17,6 +20,7 @@
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "mocha": "^7.1.1"
   }
 }

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -5,13 +5,21 @@
         module.exports = factory(exports, require('./fetchWrapper'));
     } else {
         var mod = {
-            exports: {}
+            exports: {
+                window
+            }
         };
         global.ImgixAPI = factory(mod.exports, global.fetchWrapper);
     }
 })(this, function (exports, fetchWrapper) {
     'use strict';
-    const fetch = fetchWrapper;
+    let fetch;
+
+    if (exports.window !== undefined) {
+        fetch = window.fetch;
+    } else {
+        fetch = fetchWrapper;
+    }
 
     // default ImgixAPI settings passed in during instantiation
     const DEFAULTS = {

--- a/test/browser/imgix-api-browser.js
+++ b/test/browser/imgix-api-browser.js
@@ -1,48 +1,38 @@
-const ImgixAPI = require('../src/imgix-api');
-const assert = require('assert');
+let assert = chai.assert;
 
-describe('The imgix API class', () => {
-    let ix;
-
-    before(() => {
-        ix = new ImgixAPI();
-    });
-
-    it('creates an instance of the class', () => {
-        assert(ix);
-    });
-
-    it('is created with a default version value', () => {
-        assert(ix.settings.version);
-    });
-
-    it('respects the version number passed into the constructor', () => {
-        let ix = new ImgixAPI({version: 2});
-        assert.equal(ix.settings.version, 2);
-    });
-
-    it('fetch exists in the global namespace as window.fetch', () => {
-        assert.throws(() => assert(window.fetch), Error);
-    });
-});
-
-describe('ImgixAPI.prototype.request', () => {
+describe('ImgixAPI in a browser environment', () => {
     var ix;
 
     before(() => {
         ix = new ImgixAPI();
     });
 
+    it('creates an instance of the class', () => {
+        assert.exists(ix);
+    });
+
+    it('is created with a default version value', () => {
+        assert.exists(ix.settings.version);
+    });
+
+    it('respects the version number passed into the constructor', () => {
+        var ix = new ImgixAPI({version: 2});
+        assert.equal(ix.settings.version, 2);
+    });
+
     it('exposes a method request() on the object prototype', () => {
         assert.equal(typeof ix.request, 'function');
+    });
+
+    it('fetch exists in the global namespace as window.fetch', () => {
+        assert.equal(fetch, window.fetch);
     });
 
     it('calling request() returns a Promise as a response', () => {
         const req1 = ix.request("https://api.imgix.com/api/v1/assets")
         .then(response => {
             assert.exists(response.headers);
-        })
-        .catch(() => {});
+        });
 
         assert.equal(typeof req1.then, 'function');
     });

--- a/test/browser/test.html
+++ b/test/browser/test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+<meta content="utf-8" http-equiv="encoding">
+<html>
+    <head>
+        <title>ImgixAPI Mocha Tests</title>
+        <link rel="stylesheet" href="../../node_modules/mocha/mocha.css">
+    </head>
+    <body>
+        <div id="mocha"></div>
+        <script src="../../node_modules/mocha/mocha.js"></script>
+        <script src="../../node_modules/chai/chai.js"></script>
+        <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+        <script>mocha.setup('bdd')</script>
+
+        <script src="../../src/imgix-api.js"></script>
+        <script src="imgix-api-browser.js"></script>
+
+        <script>
+            mocha.run();
+        </script>
+    </body>
+</html>

--- a/test/fetchWrapper.js
+++ b/test/fetchWrapper.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 
 describe('fetchWrapper.js', () => {
     it('exports a function', () => {
-        assert(typeof fetch === 'function');
+        assert.equal(typeof fetch, 'function');
     });
 
     it('emits a custom ApiError on failure', () => {

--- a/test/imgix-api.js
+++ b/test/imgix-api.js
@@ -14,18 +14,32 @@ describe('The imgix API class', () => {
 
     it('allows the version value to be set', () => {
         var ix = new ImgixAPI({version: 2});
-        assert(ix.settings.version == 2);
+        assert.equal(ix.settings.version, 2);
+    });
+
+    it('fetch exists in the global namespace as window.fetch', function testSpec() {
+        assert.throws(() => assert(window.fetch), Error);
     });
 });
 
 describe('ImgixAPI.prototype.request', () => {
     var ix;
 
-    beforeEach(function setupClient() {
+    before(function setupClient() {
         ix = new ImgixAPI();
     });
 
     it('exposes a method request() on the object prototype', () => {
-        assert(typeof ix.request === 'function');
+        assert.equal(typeof ix.request, 'function');
+    });
+
+    it('calling request() returns a response as a Promise', () => {
+        const req1 = ix.request("https://api.imgix.com/api/v1/assets")
+        .then(response => {
+            assert.exists(response.headers);
+        })
+        .catch(() => {});
+
+        assert.equal(typeof req1.then, 'function');
     });
 });


### PR DESCRIPTION
This PR adds logic to selectively use `window.fetch()` vs [node-fetch](https://www.npmjs.com/package/node-fetch) depending on if the module is loaded in a browser or nodejs environment. The goal of this change is to provide more flexibility so that this library can be used universally by users.

`fetchWrapper`, which uses node-fetch, currently helps to construct imgix API URLs based on a user-provided path. However, this same logic is not applied when `window.fetch()` is used, meaning the user will have to provide the full API path themselves. Ideally, these two experiences should be the same, which would require some refactoring so that API URL construction is done pre-fetch.