### PR TITLE
refactor: construct API URL prior to calling `fetch()`

### DIFF
--- a/src/fetchWrapper.js
+++ b/src/fetchWrapper.js
@@ -1,5 +1,4 @@
 const fetch = require("node-fetch");
-const API_URL = 'https://api.imgix.com/api';
 
 // Custom API error to throw
 function ApiError(message, data, status) {
@@ -21,27 +20,7 @@ function ApiError(message, data, status) {
 }
 
 // A wrapper around fetch()
-const fetchWrapper = (path = '', userOptions = {}) => {
-    const defaultOptions = {
-        method: 'get'
-    };
-
-    const defaultHeaders = {
-        'Content-Type': 'application/vnd.api+json'
-    };
-
-    const options = {
-        ...defaultOptions,
-        ...userOptions,
-        headers: {
-        ...defaultHeaders,
-        ...userOptions.headers,
-        },
-    };
-
-    const apiVersion = userOptions.version;
-    const url = `${ API_URL }/v${ apiVersion }/${ path }`;
-
+const fetchWrapper = (url = '', options = {}) => {
     /* TODO
     /* Test with uploading API
         // Detect if we are uploading a file

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -16,6 +16,8 @@
     }
 })(this, function (exports, fetchWrapper, validators) {
     'use strict';
+    const API_URL = 'https://api.imgix.com/api';
+
     const { validateOpts } = validators;
 
     // Depending on loading environment, either use
@@ -42,15 +44,30 @@
         return ImgixAPI;
     })();
 
-    ImgixAPI.prototype.request = function(path, options = {}) {
-        return fetch(path, {
-            ...options,
-            version: this.settings.version,
+    ImgixAPI.prototype.request = function(path, userOptions = {}) {
+        const defaultOptions = {
+            method: 'get'
+        };
+
+        const defaultHeaders = {
+            'Content-Type': 'application/vnd.api+json',
+            'Authorization': `apikey ${this.settings.apiKey}`
+        };
+
+        const options = {
+            ...defaultOptions,
+            ...userOptions,
             headers: {
-                'Authorization': `apikey ${this.settings.apiKey}`,
-            }
-        });
+                ...userOptions.headers,
+                ...defaultHeaders,
+            },
+        };
+        const url = constructUrl(path, this.settings.version);
+
+        return fetch(url, options);
     };
+
+    const constructUrl = (path, version) => `${ API_URL }/v${ version }/${ path }`;
 
     return ImgixAPI;
 

--- a/test/fetchWrapper.js
+++ b/test/fetchWrapper.js
@@ -9,11 +9,13 @@ describe('fetchWrapper.js', () => {
     it('emits a custom ApiError on failure', () => {
         // an empty request will fail
         fetch()
-        .catch(error => {
+        .then(error => {
+            console.log(error);
             assert(error.response);
             assert(error.message);
             assert(error.status);
             assert(error.toString);
-        });
+        })
+        .catch(() => {});
     });
 });


### PR DESCRIPTION
This PR refactors out the logic for building the API URL based on the user-provided `path` so that it is done prior to sending the request. Until now, the URL was constructed within `fetchWrapper`, which is meant to be used in a node environment only. This will give us more flexibility in the future if/when we decide to extend compatibility to the browser, ensuring that the interface will be the same in both cases.