### PR TITLE
feat: change Content-Type if user attempts to upload a valid file type

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,9 @@
 const PACKAGE_VERSION = require('../package-lock.json').version;
+const USER_AGENT = `imgix-management-js/${PACKAGE_VERSION}`;
 const API_URL = 'https://api.imgix.com/api';
 
 module.exports = {
     PACKAGE_VERSION: PACKAGE_VERSION,
+    USER_AGENT: USER_AGENT,
     API_URL: API_URL
 }

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -18,7 +18,7 @@
     'use strict';
     const API_URL = constants.API_URL;
     const USER_AGENT = `imgix-management-js/${constants.PACKAGE_VERSION}`;
-    const { validateOpts } = validators;
+    const { validateOpts, validateBody, isBuffer } = validators;
 
     // default ImgixAPI settings passed in during instantiation
     const DEFAULTS = {
@@ -45,6 +45,16 @@
             'Authorization': `apikey ${this.settings.apiKey}`,
             'User-Agent': USER_AGENT
         };
+
+        // change the Content-Type if the request body is passed a valid uploadable file type
+        let body = userOptions.body;
+        if (body) {
+            validateBody(body);
+
+            if (isBuffer(body)) {
+                defaultHeaders['Content-Type'] = 'application/octet-stream';
+            }
+        }
 
         const options = {
             ...defaultOptions,

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -52,6 +52,8 @@
 
             if (isBuffer(body)) {
                 defaultHeaders['Content-Type'] = 'application/octet-stream';
+            } else if (typeof body == 'object') {
+                userOptions.body = JSON.stringify(body);
             }
         }
 

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -16,8 +16,7 @@
     }
 })(this, function (exports, fetchWrapper, validators, constants, APIError) {
     'use strict';
-    const API_URL = constants.API_URL;
-    const USER_AGENT = `imgix-management-js/${constants.PACKAGE_VERSION}`;
+    const { API_URL, USER_AGENT } = constants;
     const { validateOpts, validateBody, isBuffer } = validators;
 
     // default ImgixAPI settings passed in during instantiation

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,12 +1,13 @@
 
 const assert = require('assert');
 
+
 function validateApiKey(value) {
-    const typeError = new TypeError('ImgixAPI.settings.apiKey must be passed a string');
+    const invalidApiKeyError = new TypeError('ImgixAPI.settings.apiKey must be passed a string');
     const legalKey = /[0-9a-f]{64}/;
     const legalKeyError = new TypeError(`${value} does not match a legal apiKey structure`);
 
-    assert(typeof value === 'string', typeError);
+    assert(typeof value === 'string', invalidApiKeyError);
     assert(legalKey.exec(value), legalKeyError);
 };
 
@@ -14,7 +15,29 @@ function validateOpts(options) {
     validateApiKey(options.apiKey);
 };
 
+function validateBody(body) {
+    const invalidBodyError = new TypeError('The request body must be of type JSON or Buffer');
+
+    assert(isJSON(body) || isBuffer(body), invalidBodyError);
+};
+
+function isBuffer(body) {
+    return Buffer.isBuffer(body);
+};
+
+function isJSON(body) {
+    try {
+        JSON.parse(body);
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
 module.exports = {
     validateApiKey: validateApiKey,
-    validateOpts: validateOpts
+    validateOpts: validateOpts,
+    validateBody: validateBody,
+    isBuffer: isBuffer,
+    isJSON: isJSON
 }

--- a/src/validators.js
+++ b/src/validators.js
@@ -16,7 +16,7 @@ function validateOpts(options) {
 };
 
 function validateBody(body) {
-    const invalidBodyError = new TypeError('The request body must be of type JSON or Buffer');
+    const invalidBodyError = new TypeError('The request body must a valid JSON object or a Buffer');
 
     const isValid = body && (isJSON(body) || isBuffer(body));
     assert(isValid, invalidBodyError);

--- a/src/validators.js
+++ b/src/validators.js
@@ -18,7 +18,10 @@ function validateOpts(options) {
 function validateBody(body) {
     const invalidBodyError = new TypeError('The request body must a valid JSON object or a Buffer');
 
-    const isValid = body && (isJSON(body) || isBuffer(body));
+    const isValid = body && (
+        isJSONString(body) ||
+        isJSONObject(body) ||
+        isBuffer(body));
     assert(isValid, invalidBodyError);
 };
 
@@ -26,19 +29,29 @@ function isBuffer(body) {
     return Buffer.isBuffer(body);
 };
 
-function isJSON(body) {
+function isJSONString(body) {
     try {
         JSON.parse(body);
     } catch (e) {
         return false;
     }
     return true;
-}
+};
+
+function isJSONObject(body) {
+    try {
+        assert.equal(typeof body, 'object');
+    } catch (e) {
+        return false;
+    }
+    return true;
+};
 
 module.exports = {
     validateApiKey: validateApiKey,
     validateOpts: validateOpts,
     validateBody: validateBody,
     isBuffer: isBuffer,
-    isJSON: isJSON
+    isJSONString: isJSONString,
+    isJSONObject: isJSONObject
 }

--- a/src/validators.js
+++ b/src/validators.js
@@ -18,7 +18,7 @@ function validateOpts(options) {
 function validateBody(body) {
     const invalidBodyError = new TypeError('The request body must be of type JSON or Buffer');
 
-    assert(isJSON(body) || isBuffer(body), invalidBodyError);
+    assert(!(isJSON(body) || isBuffer(body)), invalidBodyError);
 };
 
 function isBuffer(body) {

--- a/src/validators.js
+++ b/src/validators.js
@@ -18,7 +18,8 @@ function validateOpts(options) {
 function validateBody(body) {
     const invalidBodyError = new TypeError('The request body must be of type JSON or Buffer');
 
-    assert(!(isJSON(body) || isBuffer(body)), invalidBodyError);
+    const isValid = body && (isJSON(body) || isBuffer(body));
+    assert(isValid, invalidBodyError);
 };
 
 function isBuffer(body) {

--- a/test/constants.js
+++ b/test/constants.js
@@ -8,8 +8,9 @@ const SOURCE_ID = '012abc345def678abc901def';
 const ASSETS_ENDPOINT = `assets/${SOURCE_ID}`;
 const ASSETS_URL = apiVersion => `${ API_URL }/v${ apiVersion }/${ ASSETS_ENDPOINT }`;
 const BODY_BUFFER = new Buffer.alloc(1);
-const BODY_JSON = JSON.stringify({ data: 'test' });
-const INVALID_BODY = {};
+const BODY_JSON = { data: 'test' };
+const BODY_JSON_STRING = JSON.stringify({ data: 'test' });
+const INVALID_BODY = '{';
 const POST = 'post';
 const CONTENT_TYPE_JSON = 'application/vnd.api+json';
 const CONTENT_TYPE_OCTET = 'application/octet-stream';
@@ -24,6 +25,7 @@ module.exports = {
     ASSETS_URL: ASSETS_URL,
     BODY_BUFFER: BODY_BUFFER,
     BODY_JSON: BODY_JSON,
+    BODY_JSON_STRING: BODY_JSON_STRING,
     INVALID_BODY: INVALID_BODY,
     POST: POST,
     CONTENT_TYPE_JSON: CONTENT_TYPE_JSON,

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,21 +1,31 @@
-const API_URL = require('../src/constants').API_URL;
-const PACKAGE_VERSION = require('../src/constants').PACKAGE_VERSION;
+const { API_URL } = require('../src/constants');
 
 const API_KEY = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+const AUTHORIZATION_HEADER = `apikey ${API_KEY}`;
 const INVALID_API_KEY = 'TEST-KEY';
 const API_VERSION_OVERRIDE = 2;
 const SOURCE_ID = '012abc345def678abc901def';
 const ASSETS_ENDPOINT = `assets/${SOURCE_ID}`;
 const ASSETS_URL = apiVersion => `${ API_URL }/v${ apiVersion }/${ ASSETS_ENDPOINT }`;
-
+const BODY_BUFFER = new Buffer.alloc(1);
+const BODY_JSON = JSON.stringify({ data: 'test' });
+const INVALID_BODY = {};
+const POST = 'post';
+const CONTENT_TYPE_JSON = 'application/vnd.api+json';
+const CONTENT_TYPE_OCTET = 'application/octet-stream';
 
 module.exports = {
-    API_URL: API_URL,
-    PACKAGE_VERSION: PACKAGE_VERSION,
     API_KEY: API_KEY,
+    AUTHORIZATION_HEADER: AUTHORIZATION_HEADER,
     INVALID_API_KEY: INVALID_API_KEY,
     API_VERSION_OVERRIDE: API_VERSION_OVERRIDE,
     SOURCE_ID: SOURCE_ID,
     ASSETS_ENDPOINT: ASSETS_ENDPOINT,
-    ASSETS_URL: ASSETS_URL
+    ASSETS_URL: ASSETS_URL,
+    BODY_BUFFER: BODY_BUFFER,
+    BODY_JSON: BODY_JSON,
+    INVALID_BODY: INVALID_BODY,
+    POST: POST,
+    CONTENT_TYPE_JSON: CONTENT_TYPE_JSON,
+    CONTENT_TYPE_OCTET: CONTENT_TYPE_OCTET
 };

--- a/test/imgix-api.js
+++ b/test/imgix-api.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 // import testing constants
-const { API_KEY, AUTHORIZATION_HEADER, INVALID_API_KEY, API_VERSION_OVERRIDE, ASSETS_ENDPOINT, ASSETS_URL, BODY_BUFFER, BODY_JSON, INVALID_BODY, POST, CONTENT_TYPE_JSON, CONTENT_TYPE_OCTET } = require('./constants');
+const { API_KEY, AUTHORIZATION_HEADER, INVALID_API_KEY, API_VERSION_OVERRIDE, ASSETS_ENDPOINT, ASSETS_URL, BODY_BUFFER, BODY_JSON, BODY_JSON_STRING, INVALID_BODY, POST, CONTENT_TYPE_JSON, CONTENT_TYPE_OCTET } = require('./constants');
 const {  USER_AGENT } = require('../src/constants');
 
 describe('The ImgixAPI class', () => {
@@ -142,7 +142,49 @@ describe('ImgixAPI.prototype.request', () => {
         stubFetch.restore();
     });
 
-    it('does not change the Content-Type when a JSON blob is passed to body', () => {
+    it('does not modify a JSON string passed into body', () => {
+        const stubFetch = sinon.stub(fetchWrapper, 'fetch').returns(Promise.resolve());
+        const customOptions = {
+            method: POST,
+            body: BODY_JSON_STRING
+        };
+
+        ix.request(ASSETS_ENDPOINT, customOptions)
+        .catch(resp => resp);
+
+        const options = stubFetch.getCalls(0)[0].lastArg;
+        assert(stubFetch.callCount == 1);
+        assert(options);
+        assert.equal(typeof options, 'object');
+
+        const body = options.body;
+        assert.equal(typeof body, 'string');
+        assert.equal(body, BODY_JSON_STRING);
+        stubFetch.restore();
+    });
+
+    it('stringifies a JSON object passed into body', () => {
+        const stubFetch = sinon.stub(fetchWrapper, 'fetch').returns(Promise.resolve());
+        const customOptions = {
+            method: POST,
+            body: BODY_JSON
+        };
+
+        ix.request(ASSETS_ENDPOINT, customOptions)
+        .catch(resp => resp);
+
+        const options = stubFetch.getCalls(0)[0].lastArg;
+        assert(stubFetch.callCount == 1);
+        assert(options);
+        assert.equal(typeof options, 'object');
+
+        const body = options.body;
+        assert.equal(typeof body, 'string');
+        assert.equal(body, BODY_JSON_STRING);
+        stubFetch.restore();
+    });
+
+    it('does not change the Content-Type when a JSON object is passed to body', () => {
         const stubFetch = sinon.stub(fetchWrapper, 'fetch').returns(Promise.resolve());
         const customOptions = {
             method: POST,
@@ -155,9 +197,9 @@ describe('ImgixAPI.prototype.request', () => {
         const options = stubFetch.getCalls(0)[0].lastArg;
         assert(stubFetch.callCount == 1);
         assert.equal(typeof options, 'object');
+        
         const headers = options.headers;
         assert(headers);
-
         assert.equal(headers['Content-Type'], CONTENT_TYPE_JSON);
         stubFetch.restore();
     });
@@ -169,7 +211,7 @@ describe('ImgixAPI.prototype.request', () => {
             body: INVALID_BODY
         };
 
-        assert.throws(() => ix.request(ASSETS_ENDPOINT, customOptions).catch(resp => resp), Error);
+        assert.throws(() => ix.request(ASSETS_ENDPOINT, customOptions), Error);
         assert(stubFetch.callCount == 0);
         stubFetch.restore();
     });

--- a/test/validators.js
+++ b/test/validators.js
@@ -1,0 +1,37 @@
+const validators = require('../src/validators');
+const assert = require('assert');
+
+const { API_KEY, API_VERSION_OVERRIDE } = require('./constants');
+describe('Validators', () => {
+    context('validateApiKey', () => {
+        let invalidApiKey;
+        it('throws an error if ImgixAPI.settings.apiKey is not a string', () => {
+            invalidApiKey = 123;
+            assert.throws(() => validators.validateApiKey(invalidApiKey), Error);
+        });
+
+        it('throws an error if ImgixAPI.settings.apiKey does not adhere to the expected structure', () => {
+            invalidApiKey = 'abcdef';
+            assert.throws(() => validators.validateApiKey(invalidApiKey), Error);
+        });
+    });
+
+    context('validateOpts', () => {
+        it('throws an error if provided constructor options are invalid', () => {
+            const options = {
+                apiKey: API_KEY,
+                version: API_VERSION_OVERRIDE
+            };
+            validators.validateOpts(options);
+        });
+    });
+
+    context('validateBody', () => {
+        let body;
+
+        it('throws an error if the request body is neither type JSON nor Buffer', () => {
+            body = '123';
+            assert.throws(() => validators.validateBody(body), Error);
+        });
+    });
+})

--- a/test/validators.js
+++ b/test/validators.js
@@ -30,7 +30,7 @@ describe('Validators', () => {
         let body;
 
         it('throws an error if the request body is neither type JSON nor Buffer', () => {
-            body = '123';
+            body = null;
             assert.throws(() => validators.validateBody(body), Error);
         });
     });


### PR DESCRIPTION
This PR adds logic to validate and handle any input passed to the request `body`. For now, we only expect to support a user-provided body that is either a JSON blob or a binary [Buffer](https://nodejs.org/api/buffer.html#buffer_buffer). 

In situations where a JSON blob is provided, we can pass the body through as-is. However, if the body is a `Buffer`, we will need to change the request `Content-Type` header to `application/octet-stream`. NodeJS does not have any native `Blob` or `File` type, but we can expand these checks to include them if/when we decide to expand support to the browser.

**Note**: File [streams](https://nodejs.org/api/stream.html#stream_stream) are another input type that we can consider supporting in the future, with some extra work.