### PR TITLE
refactor: improve error handling layer

### DIFF
--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -73,17 +73,17 @@
             response = responseObject;
 
             if (response.status < 200 || response.status >= 300) {
-                return response.text();
+                return Promise.resolve(response.text());
             } else {
-                return response.json();
+                return Promise.resolve(response.json());
             }
         })
         .then(parsedResponse => {
             if (response.status < 200 || response.status >= 300) {
-                throw parsedResponse;
+                return Promise.reject(parsedResponse);
             }
 
-            return parsedResponse;
+            return Promise.resolve(parsedResponse);
         })
         .catch(error => {            
             if (response) {

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -69,20 +69,23 @@
         let response = null;
 
         return fetchWrapper.fetch(url, options)
-        .then(response => {
-            // HTTP unauthorized
-            if (response.status === 401) {
-                // Handle unauthorized requests
-            }
+        .then(responseObject => {
+            response = responseObject;
 
-            // Check for error HTTP error codes
             if (response.status < 200 || response.status >= 300) {
                 return response.text();
             } else {
                 return response.json();
             }
         })
-        .catch(error => {
+        .then(parsedResponse => {
+            if (response.status < 200 || response.status >= 300) {
+                throw parsedResponse;
+            }
+
+            return parsedResponse;
+        })
+        .catch(error => {            
             if (response) {
                 throw new APIError(`Request failed with status ${ response.status }.`, error, response.status);
             } else {


### PR DESCRIPTION
Currently, the `fetch.catch()` block only intercepts runtime errors thrown when `request()` is called. Now, even if `fetch` executes successfully, but returns a non-200 status, it will throw an error to signify an error state.

This PR provides more flexibility to users who can rely on both failed requests, and runtime errors, to funnel into the calling `catch` block.