### PR TITLE
fix: incorrectly extracted package version from package-lock file

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-const PACKAGE_VERSION = require('../package-lock.json').version;
+const PACKAGE_VERSION = require('../package.json').version;
 const USER_AGENT = `imgix-management-js/${PACKAGE_VERSION}`;
 const API_URL = 'https://api.imgix.com/api';
 


### PR DESCRIPTION
Fixes a typo that incorrectly attempts to derive the package version number (used during `USER_AGENT` construction) from the `package-lock.json` file. This file does not exist in published versions of the package, and therefore will break when used by other users.