### PR TITLE
chore: emit apiKey deprecation warning

### DIFF
--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -45,6 +45,11 @@
     function ImgixAPI(opts = {}) {
       validateOpts(opts);
       this.settings = Object.assign({}, DEFAULTS, opts);
+
+      const APIKEY_DEPRECATION_MSG =
+        'Warning: Your current `ImgixAPI.settings.apiKey` will no longer work after upgrading to imgix-management-js version >= 1.0.0.\n' +
+        'After upgrading, please regenerate your API Key at https://dashboard.imgix.com/api-keys.';
+      console.warn(APIKEY_DEPRECATION_MSG);
     }
 
     return ImgixAPI;

--- a/test/imgix-api.js
+++ b/test/imgix-api.js
@@ -50,10 +50,20 @@ describe('The ImgixAPI class', () => {
   });
 
   it('allows the API key to be set via the constructor', () => {
+    const APIKEY_DEPRECATION_MSG =
+      'Warning: Your current `ImgixAPI.settings.apiKey` will no longer work after upgrading to imgix-management-js version >= 1.0.0.\n' +
+      'After upgrading, please regenerate your API Key at https://dashboard.imgix.com/api-keys.';
+
+    var stub = sinon.stub(console, 'warn').callsFake(function (warning) {
+      assert.equal(warning, APIKEY_DEPRECATION_MSG);
+    });
+
     let ix = new ImgixAPI({
       apiKey: API_KEY,
     });
     assert.equal(ix.settings.apiKey, API_KEY);
+
+    stub.restore();
   });
 
   it('throws an error if instantiated without an API key', () => {


### PR DESCRIPTION
This PR emits a deprecation warning to alert users to regenerate their `apiKey` prior to upgrading to the next major version.