### PR TITLE
chore: change refs of `master` to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * fix: designate valid 'main' entry file ([e7df07f](https://github.com/imgix/imgix-management-js/commit/e7df07ffbc98590cbb63067887b87fd4cc1cb346))
 
-## [0.1.0](https://github.com/imgix/imgix-management-js/compare/master...v0.1.0) (2020-05-29)
+## [0.1.0](https://github.com/imgix/imgix-management-js/compare/main...v0.1.0) (2020-05-29)
 
 Exposes a client class `ImgixAPI` for making requests against the [imgix](https://www.imgix.com/) Management API.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 `imgix-management-js` is a JavaScript client library for making requests against the [imgix](https://www.imgix.com/) Management API.
 
 [![NPM Version](https://img.shields.io/npm/v/imgix-management-js.svg)](https://www.npmjs.com/package/imgix-management-js)
-[![Build Status](https://travis-ci.org/imgix/imgix-management-js.svg?branch=master)](https://travis-ci.org/imgix/imgix-management-js)
+[![Build Status](https://travis-ci.org/imgix/imgix-management-js.svg?branch=main)](https://travis-ci.org/imgix/imgix-management-js)
 [![Monthly Downloads](https://img.shields.io/npm/dm/imgix-management-js.svg)](https://www.npmjs.com/package/imgix-management-js)
 [![Minified Size](https://img.shields.io/bundlephobia/min/imgix-management-js)](https://bundlephobia.com/result?p=imgix-management-js)
-[![License](https://img.shields.io/github/license/imgix/imgix-management-js)](https://github.com/imgix/imgix-management-js/blob/master/LICENSE.md)
+[![License](https://img.shields.io/github/license/imgix/imgix-management-js)](https://github.com/imgix/imgix-management-js/blob/main/LICENSE.md)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ---


### PR DESCRIPTION
This PR changes any references from the `master` branch to the `main` branch, now that it is the default.