### PR TITLE
feat: use `Authorization: Bearer` in request header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.0.0](https://github.com/imgix/imgix-management-js/compare/v0.1.2...v1.0.0) (2020-08-05)
 
-* chore: emit `apiKey` deprecation warning [#31](https://github.com/imgix/imgix-management-js/pull/31)
+* chore: emit `apiKey` deprecation warning ([#31](https://github.com/imgix/imgix-management-js/pull/31))
 
 **Warning**: Your current `apiKey` will no longer work after upgrading to `imgix-management-js@1.0.0`. After upgrading, please regenerate your API Key at https://dashboard.imgix.com/api-keys
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ const imgix = new ImgixAPI({
 The following options can be used when creating an instance of `ImgixAPI`:
 
 - `apiKey`: String, required. The token used to authenticate API requests.
-  - **Warning**: Your current `apiKey` will no longer work after upgrading to `imgix-management-js@1.0.0`. After upgrading, please regenerate your API Key at https://dashboard.imgix.com/api-keys
 - `version`: Integer. The version of the API that will be requested against. Defaults to `1`.
 
 ## API

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -45,11 +45,6 @@
     function ImgixAPI(opts = {}) {
       validateOpts(opts);
       this.settings = Object.assign({}, DEFAULTS, opts);
-
-      const APIKEY_DEPRECATION_MSG =
-        'Warning: Your current `ImgixAPI.settings.apiKey` will no longer work after upgrading to imgix-management-js version >= 1.0.0.\n' +
-        'After upgrading, please regenerate your API Key at https://dashboard.imgix.com/api-keys.';
-      console.warn(APIKEY_DEPRECATION_MSG);
     }
 
     return ImgixAPI;

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -62,7 +62,7 @@
 
     const defaultHeaders = {
       'Content-Type': 'application/vnd.api+json',
-      Authorization: `apikey ${this.settings.apiKey}`,
+      Authorization: `Bearer ${this.settings.apiKey}`,
       'User-Agent': USER_AGENT,
     };
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -4,13 +4,8 @@ function validateApiKey(value) {
   const invalidApiKeyError = new TypeError(
     'ImgixAPI.settings.apiKey must be passed a string',
   );
-  const legalKey = /[0-9a-f]{64}/;
-  const legalKeyError = new TypeError(
-    `${value} does not match a legal apiKey structure`,
-  );
 
   assert(typeof value === 'string', invalidApiKeyError);
-  assert(legalKey.exec(value), legalKeyError);
 }
 
 function validateOpts(options) {

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,8 +1,8 @@
 const { API_URL } = require('../src/constants');
 
 const API_KEY =
-  'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
-const AUTHORIZATION_HEADER = `apikey ${API_KEY}`;
+  'ak_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+const AUTHORIZATION_HEADER = `Bearer ${API_KEY}`;
 const INVALID_API_KEY = 'TEST-KEY';
 const API_VERSION_OVERRIDE = 2;
 const SOURCE_ID = '012abc345def678abc901def';

--- a/test/imgix-api.js
+++ b/test/imgix-api.js
@@ -50,20 +50,10 @@ describe('The ImgixAPI class', () => {
   });
 
   it('allows the API key to be set via the constructor', () => {
-    const APIKEY_DEPRECATION_MSG =
-      'Warning: Your current `ImgixAPI.settings.apiKey` will no longer work after upgrading to imgix-management-js version >= 1.0.0.\n' +
-      'After upgrading, please regenerate your API Key at https://dashboard.imgix.com/api-keys.';
-
-    var stub = sinon.stub(console, 'warn').callsFake(function (warning) {
-      assert.equal(warning, APIKEY_DEPRECATION_MSG);
-    });
-
     let ix = new ImgixAPI({
       apiKey: API_KEY,
     });
     assert.equal(ix.settings.apiKey, API_KEY);
-
-    stub.restore();
   });
 
   it('throws an error if instantiated without an API key', () => {

--- a/test/imgix-api.js
+++ b/test/imgix-api.js
@@ -62,12 +62,25 @@ describe('The ImgixAPI class', () => {
     }, Error);
   });
 
-  it('throws an error if an API key does not adhere to the expected structure', () => {
-    assert.throws(() => {
-      new ImgixAPI({
-        apiKey: INVALID_API_KEY,
-      });
-    }, Error);
+  it('returns a request error if an API key does not adhere to the expected structure', () => {
+    let ix = new ImgixAPI({
+      apiKey: INVALID_API_KEY,
+    });
+
+    const EXPRECTED_ERR = 'A valid API key is required and could not be determined.';
+
+    ix.request(ASSETS_ENDPOINT).catch((error) => {
+      assert(error);
+      assert.equal(typeof error, 'object');
+      assert(error.response);
+      assert.equal(typeof error.response, 'object');
+      assert.equal(error.response.errors[0].detail, EXPRECTED_ERR);
+      assert(error.message);
+      assert.equal(typeof error.message, 'string');
+      assert(error.status);
+      assert.equal(error.status, 401);
+      assert(error.toString);
+    });
   });
 
   it('fetch exists in the global namespace as window.fetch', () => {

--- a/test/validators.js
+++ b/test/validators.js
@@ -9,11 +9,6 @@ describe('Validators', () => {
       invalidApiKey = 123;
       assert.throws(() => validators.validateApiKey(invalidApiKey), Error);
     });
-
-    it('throws an error if ImgixAPI.settings.apiKey does not adhere to the expected structure', () => {
-      invalidApiKey = 'abcdef';
-      assert.throws(() => validators.validateApiKey(invalidApiKey), Error);
-    });
   });
 
   context('validateOpts', () => {


### PR DESCRIPTION
This PR updates the default request header to use the new `Authorization: Bearer <key>` format, as specified by the imgix public API.