### PR TITLE
fix: incorrect reference to `Window` obj

### DIFF
--- a/src/fetch-wrapper.js
+++ b/src/fetch-wrapper.js
@@ -4,8 +4,8 @@ const nodeFetch = require('node-fetch');
 // window.fetch or node-fetch to complete requests
 let fetchWrapper;
 
-if (exports.window && typeof exports.window.fetch === 'function') {
-  fetchWrapper = exports.window.fetch;
+if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
+  fetchWrapper = window.fetch;
 } else {
   fetchWrapper = nodeFetch;
 }


### PR DESCRIPTION
Executing a fetch request in the browser yields the following error:

> `"TypeError: 'fetch' called on an object that does not implement interface Window."`

This may be caused by an improper assignment of `fetch` to `exports.window.fetch` when in a browser environment.