### PR TITLE
refactor: only require node-fetch in node env

### DIFF
--- a/src/fetch-wrapper.js
+++ b/src/fetch-wrapper.js
@@ -1,5 +1,3 @@
-const nodeFetch = require('node-fetch');
-
 // Depending on loading environment, either use
 // window.fetch or node-fetch to complete requests
 let fetchWrapper;
@@ -7,7 +5,7 @@ let fetchWrapper;
 if (typeof window !== 'undefined' && typeof window.fetch === 'function') {
   fetchWrapper = window.fetch.bind(window);
 } else {
-  fetchWrapper = nodeFetch;
+  fetchWrapper = require('node-fetch');
 }
 
 module.exports = {


### PR DESCRIPTION
Prevents unnecessarily `require`-ing node-fetch if imgix-management-js is run on the browser.