### PR TITLE
refactor: class APIError should extend Error interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "version": "1.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/node-fetch": "^2.5.8",
         "node-fetch": "^2.6.0"
       },
       "devDependencies": {
+        "@types/node-fetch": "^2.5.8",
         "chai": "4.3.4",
         "dtslint": "4.0.8",
         "mocha": "8.1.3",
@@ -114,14 +114,16 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
+      "version": "14.14.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+      "integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
       "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -265,7 +267,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -673,6 +676,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -784,6 +788,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1380,6 +1385,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2059,6 +2065,7 @@
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
       "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2067,6 +2074,7 @@
       "version": "2.1.29",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
       "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.46.0"
       },
@@ -3687,14 +3695,16 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
+      "version": "14.14.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+      "integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
       "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -3813,7 +3823,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -4131,6 +4142,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4223,7 +4235,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -4696,6 +4709,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5241,12 +5255,14 @@
     "mime-db": {
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.29",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
       "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.46.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "url": "git+https://github.com/imgix/imgix-management-js.git"
   },
   "dependencies": {
-    "@types/node-fetch": "^2.5.8",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
+    "@types/node-fetch": "^2.5.8",
     "chai": "4.3.4",
     "dtslint": "4.0.8",
     "mocha": "8.1.3",

--- a/src/api-error.js
+++ b/src/api-error.js
@@ -1,23 +1,27 @@
-// Custom API error to throw
-function APIError(message, data, status) {
-  let response = null;
-  let isObject = false;
+class APIError extends Error {
+  constructor(message, data, status) {
+    super(message);
+    this.name = 'APIError';
+    let response = null;
+    this.isObject = false;
 
-  try {
-    response = JSON.parse(data);
-    isObject = true;
-  } catch (e) {
-    response = data;
+    try {
+      response = JSON.parse(data);
+      this.isObject = true;
+    } catch (e) {
+      response = data;
+    }
+
+    this.response = response;
+    this.message = message;
+    this.status = status;
   }
 
-  this.response = response;
-  this.message = message;
-  this.status = status;
-
-  this.toString = () =>
-    `${this.message}\nResponse:\n${
-      isObject ? JSON.stringify(this.response, null, 2) : this.response
+  toString() {
+    return `${this.message}\nResponse:\n${
+      this.isObject ? JSON.stringify(this.response, null, 2) : this.response
     }`;
+  }
 }
 
 module.exports = APIError;

--- a/src/api-error.js
+++ b/src/api-error.js
@@ -3,7 +3,7 @@ class APIError extends Error {
     super(message);
     this.name = 'APIError';
     let response = null;
-    this.isObject = false;
+    let isObject = false;
 
     try {
       response = JSON.parse(data);
@@ -17,9 +17,9 @@ class APIError extends Error {
     this.status = status;
   }
 
-  toString() {
-    return `${this.message}\nResponse:\n${
-      this.isObject ? JSON.stringify(this.response, null, 2) : this.response
+  toString = () => {
+    return `\n${this.message}\nResponse:\n${
+      this.isObject ?  this.response : JSON.stringify(this.response, null, 2)
     }`;
   }
 }

--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -1,8 +1,9 @@
-import ImgixAPI = require('index');
+import ImgixAPI, { RequestResponse, RequestError } from 'index';
 
 const API_KEY =
   'ak_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 const SOURCE_ID = '012abc345def678abc901def';
+const BAD_REQUEST = '404_endpoint';
 const ASSETS_ENDPOINT = `assets/${SOURCE_ID}`;
 const BODY_BUFFER = Buffer.alloc(1);
 const BODY_JSON = { data: 'test' };
@@ -25,7 +26,24 @@ ix.request(`sources/upload/${SOURCE_ID}/image.jpg`, {
 });
 
 // $ExpectType Promise<RequestResponse | RequestError>
-ix.request(`sources`, {
+ix.request('sources', {
   method: 'POST',
   body: BODY_JSON,
+});
+
+// $ExpectType Promise<void>
+ix.request('sources').then((response) => {
+  response = response as RequestResponse;
+  response.data; // $ExpectType JsonMap | JsonArray
+  response.included; // $ExpectType JsonArray
+  response.jsonapi; // $ExpectType JsonMap
+  response.meta; // $ExpectType JsonMap
+});
+
+// $ExpectType Promise<void | RequestResponse | RequestError>
+ix.request(`${BAD_REQUEST}`).catch((error: RequestError) => {
+  error.response; // $ExpectType JsonMap
+  error.message; // $ExpectType string
+  error.status; // $ExpectType number
+  error.toString; // $ExpectType () => string
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,14 +6,14 @@ type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
 interface JsonMap extends Record<string, AnyJson> {}
 interface JsonArray extends Array<AnyJson> {}
 
-interface RequestResponse {
+export interface RequestResponse {
   data: JsonMap | JsonArray;
   included: JsonArray;
   jsonapi: JsonMap;
   meta: JsonMap;
 }
 
-interface RequestError extends Error {
+export interface RequestError extends Error {
   response: JsonMap;
   message: string;
   status: number;
@@ -38,4 +38,4 @@ declare class ImgixAPI {
   ): Promise<RequestResponse | RequestError>;
 }
 
-export = ImgixAPI;
+export default ImgixAPI;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ interface RequestResponse {
   meta: JsonMap;
 }
 
-interface RequestError {
+interface RequestError extends Error {
   response: JsonMap;
   message: string;
   status: number;


### PR DESCRIPTION
This PR updates the `APIError` class to be more idiomatic and extend the `Error` interface. It also expands the TS tests to account for Promises returned by the `request()` method.

Relates to #67