### PR TITLE
fix: remove ResponseError from request() return type

### DIFF
--- a/src/api-error.js
+++ b/src/api-error.js
@@ -17,8 +17,8 @@ class APIError extends Error {
 
   toString() {
     return `${this.message}
-    Response:
-    ${JSON.stringify(this.response, null, 2)}`;
+Response:
+${JSON.stringify(this.response, null, 2)}`;
   }
 }
 

--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -93,7 +93,7 @@
         }
       })
       .catch((error) => {
-        if (error?.status) {
+        if (error && error.status) {
           let response;
 
           if (typeof error.json == 'function') {

--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -13,19 +13,19 @@ const ix = new ImgixAPI({
   apiKey: API_KEY,
 });
 
-// $ExpectType Promise<RequestResponse | RequestError>
+// $ExpectType Promise<RequestResponse>
 ix.request('sources');
 
-// $ExpectType Promise<RequestResponse | RequestError>
+// $ExpectType Promise<RequestResponse>
 ix.request(`${ASSETS_ENDPOINT}`);
 
-// $ExpectType Promise<RequestResponse | RequestError>
+// $ExpectType Promise<RequestResponse>
 ix.request(`sources/upload/${SOURCE_ID}/image.jpg`, {
   method: 'POST',
   body: BODY_BUFFER,
 });
 
-// $ExpectType Promise<RequestResponse | RequestError>
+// $ExpectType Promise<RequestResponse>
 ix.request('sources', {
   method: 'POST',
   body: BODY_JSON,
@@ -39,7 +39,7 @@ ix.request('sources').then((response) => {
   response.meta; // $ExpectType JsonMap
 });
 
-// $ExpectType Promise<void | RequestResponse | RequestError>
+// $ExpectType Promise<void | RequestResponse>
 ix.request(`${BAD_REQUEST}`).catch((error: RequestError) => {
   error.response; // $ExpectType JsonMap
   error.message; // $ExpectType string
@@ -47,10 +47,8 @@ ix.request(`${BAD_REQUEST}`).catch((error: RequestError) => {
   error.toString; // $ExpectType () => string
 });
 
-async function processRequest(
-  request: Promise<RequestResponse | RequestError>,
-) {
-  // $ExpectType RequestResponse | RequestError
+async function processRequest(request: Promise<RequestResponse>) {
+  // $ExpectType RequestResponse
   const response = await request;
 }
 

--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -32,7 +32,6 @@ ix.request('sources', {
 });
 
 ix.request('sources').then((response) => {
-  response = response as RequestResponse;
   response.data; // $ExpectType JsonMap | JsonArray
   response.included; // $ExpectType JsonArray
   response.jsonapi; // $ExpectType JsonMap

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,10 +32,11 @@ declare class ImgixAPI {
 
   constructor(opts: { apiKey: string; version?: number });
 
-  request(
-    path: string,
-    options?: RequestOptions,
-  ): Promise<RequestResponse | RequestError>;
+  /**
+   * Note: on failure, this will return a type Promise\<RequestError>
+   * @see RequestError
+   */
+  request(path: string, options?: RequestOptions): Promise<RequestResponse>;
 }
 
 export default ImgixAPI;

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dtslint.json",
     "rules": {
         "semicolon": false,
-        "indent": [true, "spaces", 2]
+        "indent": [true, "spaces", 2],
+        "no-redundant-jsdoc": false
     }
 }


### PR DESCRIPTION
This PR removes the `ResponseError` type as a possible return type when invoking `request`. More information available on [this issue](https://stackoverflow.com/a/50071254/10366522). The type declaration file now includes JSDocs to notify users of what to expect when a Promise is rejected.

In addition, this PR includes two other adjustments:

- Removes an optional chain operator. This was done as a quick fix but in reality the proper approach here should be to transpile the code into a backwards-compatible version.
- Removes trailing white space from the error output in `APIError`