### PR TITLE
feat: export APIError on ImgixAPI class

### DIFF
--- a/src/imgix-api.js
+++ b/src/imgix-api.js
@@ -118,5 +118,7 @@
 
   const constructUrl = (path, version) => `${API_URL}/v${version}/${path}`;
 
+  ImgixAPI.APIError = APIError;
+
   return ImgixAPI;
 });

--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -13,6 +13,9 @@ const ix = new ImgixAPI({
   apiKey: API_KEY,
 });
 
+// $ExpectType RequestError
+ix.APIError;
+
 // $ExpectType Promise<RequestResponse>
 ix.request('sources');
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,7 @@ type RequestOptions = RequestInit | JsonBody;
 declare class ImgixAPI {
   apiKey: string;
   version: number;
+  APIError: RequestError;
 
   constructor(opts: { apiKey: string; version?: number });
 


### PR DESCRIPTION
This PR exports the `APIError` class as part of of `ImgixAPI`. This is meant to give users extra flexibility to catch a rejected Promise (when running `request()`) by casting the error as `APIError`.