### PR TITLE
fix: specify APIError as a static class property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ temp/
 test/
 .travis.yml
 .prettierrc.js
+.vscode

--- a/test/fetch-wrapper.js
+++ b/test/fetch-wrapper.js
@@ -5,10 +5,10 @@ const assert = require('assert');
 
 describe('fetchWrapper', () => {
   it('exports a function: fetch', () => {
-    assert.equal(typeof fetch, 'function');
+    assert.strictEqual(typeof fetch, 'function');
   });
 
   it('fetch returns a reference to node-fetch in a node.js env', () => {
-    assert.equal(fetch, nodeFetch);
+    assert.strictEqual(fetch, nodeFetch);
   });
 });

--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -14,7 +14,7 @@ const ix = new ImgixAPI({
 });
 
 // $ExpectType RequestError
-ix.APIError;
+ImgixAPI.APIError;
 
 // $ExpectType Promise<RequestResponse>
 ix.request('sources');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@ type RequestOptions = RequestInit | JsonBody;
 declare class ImgixAPI {
   apiKey: string;
   version: number;
-  APIError: RequestError;
+  static APIError: RequestError;
 
   constructor(opts: { apiKey: string; version?: number });
 


### PR DESCRIPTION
Follow up to #80: TypeScript does not recognize `APIError` as a property on `ImgixAPI` unless the type definition specifies it as a static class property.