### PR TITLE
fix: rename RequestError to APIError to match class name

### DIFF
--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -1,4 +1,4 @@
-import ImgixAPI, { RequestResponse, RequestError } from 'index';
+import ImgixAPI, { RequestResponse, APIError } from 'index';
 
 const API_KEY =
   'ak_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
@@ -13,7 +13,7 @@ const ix = new ImgixAPI({
   apiKey: API_KEY,
 });
 
-// $ExpectType RequestError
+// $ExpectType APIError
 ImgixAPI.APIError;
 
 // $ExpectType Promise<RequestResponse>
@@ -42,7 +42,7 @@ ix.request('sources').then((response) => {
 });
 
 // $ExpectType Promise<void | RequestResponse>
-ix.request(`${BAD_REQUEST}`).catch((error: RequestError) => {
+ix.request(`${BAD_REQUEST}`).catch((error: APIError) => {
   error.response; // $ExpectType JsonMap
   error.message; // $ExpectType string
   error.status; // $ExpectType number

--- a/types/imgix-api-test.ts
+++ b/types/imgix-api-test.ts
@@ -55,3 +55,14 @@ async function processRequest(request: Promise<RequestResponse>) {
 }
 
 processRequest(ix.request('sources'));
+
+try {
+  () => {};
+} catch (error) {
+  if (error instanceof APIError) {
+    error.response; // $ExpectType JsonMap
+    error.message; // $ExpectType string
+    error.status; // $ExpectType number
+    error.toString(); // $ExpectType string
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ export interface RequestResponse {
   meta: JsonMap;
 }
 
-export interface RequestError extends Error {
+export interface APIError extends Error {
   response: JsonMap;
   message: string;
   status: number;
@@ -29,13 +29,13 @@ type RequestOptions = RequestInit | JsonBody;
 declare class ImgixAPI {
   apiKey: string;
   version: number;
-  static APIError: RequestError;
+  static APIError: APIError;
 
   constructor(opts: { apiKey: string; version?: number });
 
   /**
-   * Note: on failure, this will return a type Promise\<RequestError>
-   * @see RequestError
+   * Note: on failure, this will return a type Promise\<APIError>
+   * @see APIError
    */
   request(path: string, options?: RequestOptions): Promise<RequestResponse>;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ export interface RequestResponse {
 }
 
 export class APIError extends Error {
+  constructor(message: string, data: JsonMap | null, status: number);
   response: JsonMap;
   message: string;
   status: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ export interface RequestResponse {
   meta: JsonMap;
 }
 
-export interface APIError extends Error {
+export class APIError extends Error {
   response: JsonMap;
   message: string;
   status: number;


### PR DESCRIPTION
This PR changes the `interface RequestError` to `class APIError` to more accurately reflect the actual type of the error class.