### PR TITLE
chore(readme): fixes paths in example requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ imgix.request(`assets/${sourceId}/uploads/pecanpie.jpg`)
 ```js
 var document = {
     'data': {
-        'id': `${sourceId}/uploads/pecanpie.jpg`,
+        'id': `${sourceId}/pecanpie.jpg`,
         'type': 'assets',
         'attributes': {}
     }
 };
 
-imgix.request(`assets/${sourceId}/uploads/pecanpie.jpg`)
+imgix.request(`sources/${sourceId}/assets/pecanpie.jpg`)
 .then(response => {
     /*
     ** Populate `document` with all pre-existing fields
@@ -129,7 +129,7 @@ imgix.request(`assets/${sourceId}/uploads/pecanpie.jpg`)
     document.data.attributes.custom_fields.type = 'dessert';
 
     // PATCH request to write in new custom field
-    imgix.request(`assets/${sourceId}/uploads/pecanpie.jpg`, {
+    imgix.request(`sources/${sourceId}/assets/pecanpie.jpg`, {
         method: 'PATCH',
         body: document
     })


### PR DESCRIPTION
Found a small discrepancy when using the readme's instructions and the module. For reference in docs (https://docs.imgix.com/apis/management#asset-operations) the patch endpoint is `sources/<sourceID>/assets/<path-to-image>`. 

Example Error (when using readme's instructions) for from GET `assets/<sourceID>/uploads/<path-to-image>`:
```
{
  "errors": [
    {
      "detail": "Resource not found.",
      "id": "<ID>",
      "meta": {},
      "status": "404",
      "title": "NotFound"
    }
  ]
}
```