### PR TITLE
ci: remove travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-
-before_install:
-  - npm install -g npm@latest
-
-node_js:
-  - stable
-  - lts/*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `imgix-management-js` is a JavaScript client library for making requests against the [imgix](https://www.imgix.com/) Management API.
 
 [![NPM Version](https://img.shields.io/npm/v/imgix-management-js.svg)](https://www.npmjs.com/package/imgix-management-js)
-[![Build Status](https://travis-ci.org/imgix/imgix-management-js.svg?branch=main)](https://travis-ci.org/imgix/imgix-management-js)
+[![Build Status](https://circleci.com/gh/imgix/imgix-management-js.svg?style=shield)](https://circleci.com/gh/imgix/imgix-management-js)
 [![Monthly Downloads](https://img.shields.io/npm/dm/imgix-management-js.svg)](https://www.npmjs.com/package/imgix-management-js)
 [![Minified Size](https://img.shields.io/bundlephobia/min/imgix-management-js)](https://bundlephobia.com/result?p=imgix-management-js)
 [![License](https://img.shields.io/github/license/imgix/imgix-management-js)](https://github.com/imgix/imgix-management-js/blob/main/LICENSE.md)


### PR DESCRIPTION
This PR removes references to Travis CI as this project is now migrating over to CircleCI